### PR TITLE
Rename TabClip references

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,4 +40,4 @@ jobs:
       - run: npx webpack
 
       - store_artifacts:
-          path: dist/tabclip.zip
+          path: dist/tabclipper.zip

--- a/README.md
+++ b/README.md
@@ -1,21 +1,22 @@
-# tabclip
+# TabClipper
 
-<img src="https://raw.githubusercontent.com/joshdick/tabclip/master/assets/screenshot.png" title="Tabclip screenshot" alt="Tabclip screenshot" width="1280" />
+<img src="assets/screenshot.png" title="TabClipper screenshot" alt="TabClipper screenshot" width="1280" />
 
 Copy browser tabs to (or create them from) your clipboard.
+TabClipper is a fork of Josh Dick's TabClip extension maintained by Sajid Ahamed.
 
 Get the extension:
 
-<a href="https://addons.mozilla.org/firefox/addon/tabclip/">
-	<img src="https://raw.githubusercontent.com/joshdick/tabclip/master/assets/firefox.png" title="Firefox logo" alt="Firefox logo" width="150" />
+<a href="https://addons.mozilla.org/firefox/addon/tabclipper/">
+        <img src="assets/firefox.png" title="Firefox logo" alt="Firefox logo" width="150" />
 </a>
-<a href="https://chrome.google.com/webstore/detail/tabclip/kdmfphcdeckocjmkmkgffgehadjhmkmc">
-	<img src="https://raw.githubusercontent.com/joshdick/tabclip/master/assets/chrome.png" title="Chrome logo" alt="Chrome logo" width="150" />
+<a href="https://chrome.google.com/webstore/detail/tabclipper/kdmfphcdeckocjmkmkgffgehadjhmkmc">
+        <img src="assets/chrome.png" title="Chrome logo" alt="Chrome logo" width="150" />
 </a>
 
 ## About
 
-Tabclip is a web browser extension for Mozilla Firefox and Google Chrome that allows you to copy browser tabs to (or create them from) your clipboard.
+TabClipper is a web browser extension for Mozilla Firefox and Google Chrome that allows you to copy browser tabs to (or create them from) your clipboard.
 
 The "Copy" button, or keyboard shortcut CTRL+SHIFT+C by default, copies tab URLs to your clipboard.
 
@@ -25,25 +26,25 @@ That's it!
 
 ## Feedback
 
-If you have suggestions or bug reports for tabclip, I am much more likely to see your feedback if you leave it at [tabclip's GitHub Issues page](https://github.com/joshdick/tabclip/issues) rather than on tabclip's Firefox Add-Ons or Chrome Web Store pages.
+If you have suggestions or bug reports for TabClipper, I am much more likely to see your feedback if you leave it at [TabClipper's GitHub Issues page](https://github.com/sajidahamed/tabclipper/issues) rather than on TabClipper's Firefox Add-Ons or Chrome Web Store pages.
 
 I'd like to keep this extension as simple and minimal as possible, so most feature requests are not likely to be honored.
 
 ## Development
 
-To build tabclip for both Firefox and Chrome, install the latest versions of NodeJS and `npm`, then do the following:
+To build TabClipper for both Firefox and Chrome, install the latest versions of NodeJS and `npm`, then do the following:
 
 ```bash
-git clone https://github.com/joshdick/tabclip.git
-cd tabclip
+git clone https://github.com/sajidahamed/tabclipper.git
+cd tabclipper
 npm install
 npx webpack
 ```
 
-The build will create a `tabclip.zip` extension archive in the `dist/` directory.
+The build will create a `TabClipper.zip` extension archive in the `dist/` directory.
 
 ## Attribution
 
-Tabclip is heavily inspired by Vincent Paré's ["Copy All Urls" Chrome extension](https://chrome.google.com/webstore/detail/copy-all-urls/djdmadneanknadilpjiknlnanaolmbfk). I created tabclip because I wanted a similar extension that looked and worked the same in both Chrome and Firefox. Tabclip was written from scratch and shares no code with the "Copy All Urls" Chrome extension.
+TabClipper is heavily inspired by Vincent Paré's ["Copy All Urls" Chrome extension](https://chrome.google.com/webstore/detail/copy-all-urls/djdmadneanknadilpjiknlnanaolmbfk). I created TabClipper because I wanted a similar extension that looked and worked the same in both Chrome and Firefox. TabClipper was written from scratch and shares no code with the "Copy All Urls" Chrome extension.
 
-Tabclip's [icon](https://www.flaticon.com/free-icon/design-tab_68369) was made by [Freepik](https://www.flaticon.com/authors/freepik) from [flaticon.com](https://www.flaticon.com/).
+TabClipper's [icon](https://www.flaticon.com/free-icon/design-tab_68369) was made by [Freepik](https://www.flaticon.com/authors/freepik) from [flaticon.com](https://www.flaticon.com/).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "tabclip",
+  "name": "tabclipper",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tabclip",
+  "name": "tabclipper",
   "version": "1.0.0",
   "description": "Copy browser tabs to (or create them from) your clipboard.",
   "private": true,
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/joshdick/tabclip.git"
+    "url": "https://github.com/sajidahamed/tabclipper.git"
   },
   "keywords": [
     "browser",
@@ -21,12 +21,12 @@
     "copy",
     "paste"
   ],
-  "author": "Josh Dick <https://joshdick.net>",
+  "author": "Sajid Ahamed (forked from Josh Dick)",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/joshdick/tabclip/issues"
+    "url": "https://github.com/sajidahamed/tabclipper/issues"
   },
-  "homepage": "https://joshdick.github.io/tabclip",
+  "homepage": "https://github.com/sajidahamed/tabclipper",
   "dependencies": {
     "@fortawesome/fontawesome": "^1.1.8",
     "@fortawesome/fontawesome-free-solid": "^5.0.13",

--- a/src/background.js
+++ b/src/background.js
@@ -5,10 +5,10 @@ const showNotification = async (quantity, operation) => {
 	const idSuffix = operation === shared.ALERT_OPERATIONS.COPY ? 'copy' : 'paste'
 	const titleVerb = operation === shared.ALERT_OPERATIONS.COPY ? 'Copy' : 'Paste'
 	const messageVerb = operation === shared.ALERT_OPERATIONS.COPY ? 'Copied' : 'Pasted'
-	await browser.notifications.create(`tabclip-${idSuffix}`, {
+	await browser.notifications.create(`tabclipper-${idSuffix}`, {
 		type: 'basic',
 		iconUrl: browser.extension.getURL('img/tabclip_128.png'),
-		title: `Tabclip ${titleVerb}`,
+		title: `TabClipper ${titleVerb}`,
 		message: `${messageVerb} ${quantity} URL${quantity === 1 ? '' : 's'}.`,
 	})
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
         "manifest_version": 3,
-	"name": "tabclip",
+	"name": "tabclipper",
 	"description": "Copy browser tabs to (or create them from) your clipboard.",
 	"version": "1.4",
 	"author": "Josh Dick",
@@ -10,11 +10,11 @@
 		"48": "img/tabclip_48.png",
 		"128": "img/tabclip_128.png"
 	},
-	"homepage_url": "https://joshdick.github.io/tabclip",
+	"homepage_url": "https://github.com/sajidahamed/tabclipper",
         "action": {
                 "default_icon": "img/tabclip_128.png",
                 "default_popup": "popup.htm",
-                "default_title": "tabclip"
+                "default_title": "TabClipper"
         },
         "background": {
                 "service_worker": "background.bundle.js"

--- a/src/popup.htm
+++ b/src/popup.htm
@@ -5,7 +5,7 @@
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-		<title>tabclip</title>
+		<title>TabClipper</title>
 
 		<style type="text/css">
 			body {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,7 +8,7 @@ const ZipPlugin = require('zip-webpack-plugin')
 
 const zipPluginConfig = {
 	exclude: ['.DS_Store'],
-	filename: 'tabclip.zip',
+	filename: 'tabclipper.zip',
 	// yazl Options
 	// OPTIONAL: see https://github.com/thejoshwolfe/yazl#addfilerealpath-metadatapath-options
 	fileOptions: {


### PR DESCRIPTION
## Summary
- rename TabClip to **TabClipper** across documentation and configs
- update repository links and metadata to point at Sajid Ahamed's fork

## Testing
- `npm test` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_687a4f6cf4b88329b9e78fd9843fdadf